### PR TITLE
Add support for curl proxy when accessing Google spell service.

### DIFF
--- a/classes/GoogleSpell.php
+++ b/classes/GoogleSpell.php
@@ -79,6 +79,26 @@ class GoogleSpell extends SpellChecker {
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $header);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+			if (!empty($this->_config['GoogleSpell.proxyhost'])) {
+				if (!empty($this->_config['GoogleSpell.proxytype']) and ($this->_config['GoogleSpell.proxytype'] === 'SOCKS5')) {
+                    curl_setopt($ch, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
+				} else {
+                    curl_setopt($ch, CURLOPT_PROXYTYPE, CURLPROXY_HTML);
+                    curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, FALSE);
+                }
+				if (empty($this->_config['GoogleSpell.proxyport'])) {
+					curl_setopt($ch, CURLOPT_PROXY, $this->_config['GoogleSpell.proxyhost']);
+				} else {
+					curl_setopt($ch, CURLOPT_PROXY, $this->_config['GoogleSpell.proxyhost'].':'.$this->_config['GoogleSpell.proxyport']);
+				}
+				if (!empty($this->_config['GoogleSpell.proxyuser']) and !empty($this->_config['GoogleSpell.proxypassword'])) {
+					curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->_config['GoogleSpell.proxyuser'].':'.$this->_config['GoogleSpell.proxypassword']);
+					if (defined('CURLOPT_PROXYAUTH')) {
+						// any proxy authentication if PHP 5.1
+						curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_BASIC | CURLAUTH_NTLM);
+					}
+				}
+			}
 			$xml = curl_exec($ch);
 			curl_close($ch);
 		} else {

--- a/config.php
+++ b/config.php
@@ -10,6 +10,13 @@
 	//$config['general.engine'] = 'PSpellShell';
 	//$config['general.remote_rpc_url'] = 'http://some.other.site/some/url/rpc.php';
 
+	// GoogleSpell settings
+	//$config['GoogleSpell.proxyhost'] = '192.168.1.1';
+	//$config['GoogleSpell.proxyport'] = 3128;
+	//$config['GoogleSpell.proxytype'] = 'HTML'; // or SOCKS5
+	//$config['GoogleSpell.proxyuser'] = '';
+	//$config['GoogleSpell.proxypassword'] = '';
+
 	// PSpell settings
 	$config['PSpell.mode'] = PSPELL_FAST;
 	$config['PSpell.spelling'] = "";


### PR DESCRIPTION
Hello, I thought you might be interested in this patch that adds proxy support when using Google spell service. This is my first Pull request for anything TinyMCE related, if there is something more I should do please let me know. Thanks.

Petr
