### PR TITLE
use utf-8 encoding by default in PSpell class

### DIFF
--- a/classes/PSpell.php
+++ b/classes/PSpell.php
@@ -21,7 +21,7 @@ class PSpell extends SpellChecker {
 		$outWords = array();
 		foreach ($words as $word) {
 			if (!pspell_check($plink, trim($word)))
-				$outWords[] = utf8_encode($word);
+				$outWords[] = $word;
 		}
 
 		return $outWords;
@@ -36,9 +36,6 @@ class PSpell extends SpellChecker {
 	 */
 	function &getSuggestions($lang, $word) {
 		$words = pspell_suggest($this->_getPLink($lang), $word);
-
-		for ($i=0; $i<count($words); $i++)
-			$words[$i] = utf8_encode($words[$i]);
 
 		return $words;
 	}
@@ -56,7 +53,7 @@ class PSpell extends SpellChecker {
 			$lang,
 			$this->_config['PSpell.spelling'],
 			$this->_config['PSpell.jargon'],
-			$this->_config['PSpell.encoding'],
+			empty($this->_config['PSpell.encoding']) ? 'utf-8' : $this->_config['PSpell.encoding'],
 			$this->_config['PSpell.mode']
 		);
 


### PR DESCRIPTION
TinyMCE sends all strings already in UTF-8, checkWords() was incorrectly double encoding and suggestions are most probably in UTF-8 already and if not we do not know for sure which encoding was used unless we set it in config.
