### PR TITLE
Fixed suggestions encoding on GoogleSpell

### DIFF
--- a/classes/GoogleSpell.php
+++ b/classes/GoogleSpell.php
@@ -4,7 +4,7 @@
  *
  * @package MCManager.includes
  * @author Moxiecode
- * @copyright Copyright © 2004-2007, Moxiecode Systems AB, All rights reserved.
+ * @copyright Copyright ï¿½ 2004-2007, Moxiecode Systems AB, All rights reserved.
  */
 
 class GoogleSpell extends SpellChecker {
@@ -39,7 +39,7 @@ class GoogleSpell extends SpellChecker {
 		$matches = $this->_getMatches($lang, $word);
 
 		if (count($matches) > 0)
-			$sug = explode("\t", utf8_encode($this->_unhtmlentities($matches[0][4])));
+			$sug = explode("\t", $this->_unhtmlentities($matches[0][4]));
 
 		// Remove empty
 		foreach ($sug as $item) {


### PR DESCRIPTION
GoogleSpell already returns suggestion as UTF-8. Don't run results through utf8_encode or it breaks encoding

See http://core.trac.wordpress.org/ticket/20016
