### PR TITLE
Ignored Words List

### DIFF
--- a/classes/EnchantSpell.php
+++ b/classes/EnchantSpell.php
@@ -19,8 +19,8 @@ class EnchantSpell extends SpellChecker {
 	 */
 	function &checkWords($lang, $words) {
 		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
-			if ( $index = array_search( $ignore, $words ) ) {
-				array_splice( $words, $index, 1 );
+			if ( false !== $index = array_search( $ignore, $words ) ) {
+				unset( $words[ $index ] );
 			}
 		}
 		$r = enchant_broker_init();

--- a/classes/EnchantSpell.php
+++ b/classes/EnchantSpell.php
@@ -18,6 +18,11 @@ class EnchantSpell extends SpellChecker {
 	 * @return Array of misspelled words.
 	 */
 	function &checkWords($lang, $words) {
+		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
+			if ( $index = array_search( $ignore, $words ) ) {
+				array_splice( $words, $index, 1 );
+			}
+		}
 		$r = enchant_broker_init();
 		
 		if (enchant_broker_dict_exists($r,$lang)) {

--- a/classes/GoogleSpell.php
+++ b/classes/GoogleSpell.php
@@ -16,6 +16,11 @@ class GoogleSpell extends SpellChecker {
 	 * @return {Array} Array of misspelled words.
 	 */
 	function &checkWords($lang, $words) {
+		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
+			if ( $index = array_search( $ignore, $words ) ) {
+				array_splice( $words, $index, 1 );
+			}
+		}
 		$wordstr = implode(' ', $words);
 		$matches = $this->_getMatches($lang, $wordstr);
 		$words = array();

--- a/classes/GoogleSpell.php
+++ b/classes/GoogleSpell.php
@@ -17,8 +17,8 @@ class GoogleSpell extends SpellChecker {
 	 */
 	function &checkWords($lang, $words) {
 		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
-			if ( $index = array_search( $ignore, $words ) ) {
-				array_splice( $words, $index, 1 );
+			if ( false !== $index = array_search( $ignore, $words ) ) {
+				unset( $words[ $index ] );
 			}
 		}
 		$wordstr = implode(' ', $words);

--- a/classes/PSpell.php
+++ b/classes/PSpell.php
@@ -16,6 +16,11 @@ class PSpell extends SpellChecker {
 	 * @return {Array} Array of misspelled words.
 	 */
 	function &checkWords($lang, $words) {
+		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
+			if ( $index = array_search( $ignore, $words ) ) {
+				array_splice( $words, $index, 1 );
+			}
+		}
 		$plink = $this->_getPLink($lang);
 
 		$outWords = array();

--- a/classes/PSpell.php
+++ b/classes/PSpell.php
@@ -17,8 +17,8 @@ class PSpell extends SpellChecker {
 	 */
 	function &checkWords($lang, $words) {
 		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
-			if ( $index = array_search( $ignore, $words ) ) {
-				array_splice( $words, $index, 1 );
+			if ( false !== $index = array_search( $ignore, $words ) ) {
+				unset( $words[ $index ] );
 			}
 		}
 		$plink = $this->_getPLink($lang);

--- a/classes/PSpellShell.php
+++ b/classes/PSpellShell.php
@@ -17,8 +17,8 @@ class PSpellShell extends SpellChecker {
 	 */
 	function &checkWords($lang, $words) {
 		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
-			if ( $index = array_search( $ignore, $words ) ) {
-				array_splice( $words, $index, 1 );
+			if ( false !== $index = array_search( $ignore, $words ) ) {
+				unset( $words[ $index ] );
 			}
 		}
 		$cmd = $this->_getCMD($lang);

--- a/classes/PSpellShell.php
+++ b/classes/PSpellShell.php
@@ -16,6 +16,11 @@ class PSpellShell extends SpellChecker {
 	 * @return {Array} Array of misspelled words.
 	 */
 	function &checkWords($lang, $words) {
+		foreach ( explode( ' ', $this->config['general.ignored_words'] ) as $ignore ) {
+			if ( $index = array_search( $ignore, $words ) ) {
+				array_splice( $words, $index, 1 );
+			}
+		}
 		$cmd = $this->_getCMD($lang);
 
 		if ($fh = fopen($this->_tmpfile, "w")) {

--- a/config.php
+++ b/config.php
@@ -9,6 +9,7 @@
 	//$config['general.engine'] = 'PSpell';
 	//$config['general.engine'] = 'PSpellShell';
 	//$config['general.remote_rpc_url'] = 'http://some.other.site/some/url/rpc.php';
+	$config['general.ignored_words'] = 'TinyMCE WordPress';
 
 	// PSpell settings
 	$config['PSpell.mode'] = PSPELL_FAST;


### PR DESCRIPTION
Allow users/applications to define a custom dictionary of ignored word by adding a space-delimited list to `$config['general.ignored_words']` in `config.php`.

As an example, I've added both "WordPress" and "TinyMCE" to the list of ignored words in the configuration file since both are inaccurately flagged as misspellings. Making this a configurable option allows other users to add their own application/product/exotic names so that they aren't constantly flagged by the software.
