### PR TITLE
Bug Fix for issue 2678 - Adding proxy support for GoogleSpell

### DIFF
--- a/classes/GoogleSpell.php
+++ b/classes/GoogleSpell.php
@@ -83,6 +83,39 @@ class GoogleSpell extends SpellChecker {
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $header);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+			if (is_numeric($this->_config['GoogleSpell.connection.timeout']))
+			{
+				curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+			}
+			if (isset($this->_config['GoogleSpell.proxy.server']) && trim($this->_config['GoogleSpell.proxy.server'] != ""))
+			{
+				if ($this->_config['GoogleSpell.proxy.type'] == "http")
+				{
+					curl_setopt($ch, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+					curl_setopt($ch, CURLOPT_PROXY, "http://".$this->_config['GoogleSpell.proxy.server']);
+				}
+				else if($this->_config['GoogleSpell.proxy.type'] == "socks")
+				{
+					curl_setopt($ch, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
+					curl_setopt($ch, CURLOPT_PROXY, $this->_config['GoogleSpell.proxy.server']);
+				}
+				if (is_numeric($this->_config['GoogleSpell.proxy.port']))
+				{
+					curl_setopt($ch, CURLOPT_PROXYPORT, $this->_config['GoogleSpell.proxy.port']);
+				}
+				if ($this->_config['GoogleSpell.proxy.auth'] == "basic")
+				{
+					curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_BASIC);
+				}
+				elseif ($this->_config['GoogleSpell.proxy.auth'] == "ntlm")
+				{
+					curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_NTLM);
+				}
+				if (trim($this->_config['GoogleSpell.proxy.user']) != "")
+				{
+					curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->_config['GoogleSpell.proxy.user'].":".$this->_config['GoogleSpell.proxy.password']);
+				}
+			}
 			$xml = curl_exec($ch);
 			curl_close($ch);
 		} else {

--- a/config.php
+++ b/config.php
@@ -24,4 +24,13 @@
 	// Windows PSpellShell settings
 	//$config['PSpellShell.aspell'] = '"c:\Program Files\Aspell\bin\aspell.exe"';
 	//$config['PSpellShell.tmp'] = 'c:/temp';
+
+	//GoogleSpell Proxy options
+	//$config['GoogleSpell.proxy.type'] = 'http';
+	//$config['GoogleSpell.proxy.server'] = 'my.proxy.server';
+	//$config['GoogleSpell.proxy.port'] = '3128';
+	//$config['GoogleSpell.proxy.auth'] = 'basic';
+	//$config['GoogleSpell.proxy.user'] = 'username';
+	//$config['GoogleSpell.proxy.password'] = 'password';
+	//$config['GoogleSpell.connection.timeout'] = 10;
 ?>


### PR DESCRIPTION
Implements code supplied in the bug report

http://www.tinymce.com/develop/bugtracker_view.php?id=2678

Adds support for proxies using Curl in the GoogleSpell class. I have
name spaced these under GoogleSpell.

New settings are set in config.php
GoogleSpell.proxy.type    - http or socks
GoogleSpell.proxy.server - e.g. my.proxy.server
GoogleSpell.proxy.port - e.g. 3127
GoogleSpell.proxy.auth - e.g basic
GoogleSpell.proxy.user - e.g. username
GoogleSpell.proxy.password - e.g. password
GoogleSpell.connection.timeout - e.g. 10
