### PR TITLE
Removed broken Content-Encoding header

### DIFF
--- a/includes/SpellChecker.php
+++ b/includes/SpellChecker.php
@@ -65,8 +65,7 @@ class TinyMCE_SpellChecker {
 		$engine = new $engine();
 		$engine->setConfig($tinymceSpellcheckerConfig);
 
-		header('Content-Type: application/json');
-		header('Content-Encoding: UTF-8');
+		header("Content-Type: application/json; charset=utf-8");
 		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
 		header("Cache-Control: no-store, no-cache, must-revalidate");


### PR DESCRIPTION
Updated version of PR #7 for version 4.0. "Content-encoding" is meant for values such as "gzip" and not for character encodings such as UTF-8.
