### PR TITLE
Adding English British to list of available languages

### DIFF
--- a/editor_plugin_src.js
+++ b/editor_plugin_src.js
@@ -99,7 +99,7 @@
 
 			// Find selected language
 			t.languages = {};
-			each(ed.getParam('spellchecker_languages', '+English=en,Danish=da,Dutch=nl,Finnish=fi,French=fr,German=de,Italian=it,Polish=pl,Portuguese=pt,Spanish=es,Swedish=sv', 'hash'), function(v, k) {
+			each(ed.getParam('spellchecker_languages', '+English=en,English British=en_gb,Danish=da,Dutch=nl,Finnish=fi,French=fr,German=de,Italian=it,Polish=pl,Portuguese=pt,Spanish=es,Swedish=sv', 'hash'), function(v, k) {
 				if (k.indexOf('+') === 0) {
 					k = k.substring(1);
 					t.selectedLang = v;


### PR DESCRIPTION
This adds an 'English British' option to the spellcheck dropdown lang selector.

Note, Aspell ships with en_gb. 

I would like to add en_au also but the dictionaries are hard to come by. 
