### PR TITLE
Fix pspell in a way it adds suggestions and makes sure the output is utf-8

### DIFF
--- a/includes/PSpellEngine.php
+++ b/includes/PSpellEngine.php
@@ -20,7 +20,7 @@ class TinyMCE_SpellChecker_PSpellEngine extends TinyMCE_SpellChecker_Engine {
 	public function getSuggestions($lang, $words) {
 		$config = $this->getConfig();
 
-		switch ($config['PSpell.mode']) {
+		switch ($config['pspell.mode']) {
 			case "fast":
 				$mode = PSPELL_FAST;
 				break;
@@ -38,7 +38,7 @@ class TinyMCE_SpellChecker_PSpellEngine extends TinyMCE_SpellChecker_Engine {
 			$lang,
 			$config['pspell.spelling'],
 			$config['pspell.jargon'],
-			$config['pspell.encoding'],
+			empty($config['pspell.encoding']) ? 'utf-8' : $config['pspell.encoding'],
 			$mode
 		);
 
@@ -49,7 +49,11 @@ class TinyMCE_SpellChecker_PSpellEngine extends TinyMCE_SpellChecker_Engine {
 		$outWords = array();
 		foreach ($words as $word) {
 			if (!pspell_check($plink, trim($word))) {
-				$outWords[] = utf8_encode($word);
+                $suggestions = pspell_suggest($plink, $word);
+                array_walk($suggestions, function (&$value) {
+                    $value = mb_convert_encoding($value, 'UTF-8', mb_detect_encoding($value));
+                });
+				$outWords[$word] = $suggestions;
 			}
 		}
 


### PR DESCRIPTION
A couple of PR's here try to fix this, but none of them actually takes output encoding serious.
Some just blindly utf-8 encode it, which gives problems when pspell_suggest already outputs utf-8 (double encoding).
Others just expect pspell_suggest to output utf-8, which is not true.

So my fix detects the encoding of every suggestion and encodes it as utf-8 if it is not already.
Tested with english, dutch, german, swedish and spanish.
